### PR TITLE
Recursively convert MSObject to NSDictionary when serializing MSObject

### DIFF
--- a/BaseModels/MSObject.m
+++ b/BaseModels/MSObject.m
@@ -63,6 +63,9 @@
         } else if ([dictionary[key] isKindOfClass:[NSArray class]]) {
             NSArray *array = dictionary[key];
             convertedDictionary[key] = [self recursivelyConvertObjectsToDictionariesInArray:array];
+        } else if ([dictionary[key] respondsToSelector:@selector(ms_toString)]) {
+            NSString *enumValue = [dictionary[key] performSelector:@selector(ms_toString)];
+            convertedDictionary[key] = enumValue;
         } else {
             convertedDictionary[key] = dictionary[key];
         }
@@ -79,6 +82,9 @@
         } else if ([item isKindOfClass:[NSArray class]]) {
             NSArray *array = item;
             [convertedArray addObject:[self recursivelyConvertObjectsToDictionariesInArray:array]];
+        } else if ([item respondsToSelector:@selector(ms_toString)]) {
+            NSString *enumValue = [item performSelector:@selector(ms_toString)];
+            [convertedArray addObject:enumValue];
         } else {
             [convertedArray addObject:item];
         }


### PR DESCRIPTION
Fixes #27

As proposed in https://github.com/microsoftgraph/msgraph-sdk-objc-models/issues/27#issuecomment-539474103, this PR enhances the `-[getSerializedDataWithError:]` method in `MSObject` by recursively converting `MSObject`s to `NSDictionary`.

Since I have no idea how the models are actually generated, I didn't propose a solution that would make the dictionaries serializable from the get-go.