### PR TITLE
Include MSCollection.h in the umbrella header.

### DIFF
--- a/GeneratedModels/MSGraphClientModels.h
+++ b/GeneratedModels/MSGraphClientModels.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 
-
+#import "MSCollection.h"
 #import "MSDate.h"
 #import "MSTimeOfDay.h"
 #import "MSDuration.h"


### PR DESCRIPTION
GraphTutorial uses MSCollection, but it isn't included in the umbrella header.

This doesn't matter if you build with cocoapods, but does if you try to use the sample code elsewhere.