### PR TITLE
Fixed Header Visibility

### DIFF
--- a/GeneratedModels/MSGraphClientModels.h
+++ b/GeneratedModels/MSGraphClientModels.h
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 
 
-
+#import "MSCollection.h"
 #import "MSDate.h"
 #import "MSTimeOfDay.h"
 #import "MSDuration.h"


### PR DESCRIPTION
Some files mentioned in the umbrella header had their visibility set to `project`. 

`MSCollection.h` was also missing from the umbrella header.

This causes problems when building as an XCFramework.